### PR TITLE
Add Hollywood-style hacking simulator web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # hollywoodhacker
-Hollywood and TV-show inspired attack and hacking simulator
+
+Hollywood and TV-show inspired attack and hacking simulator.
+
+Open `index.html` in a browser to run the simulator.
+The page displays scrolling logs, a world map with attack traces and firewall breach indicators.
+Explore the fictional file browser and use the "Deploy Countermeasure" button to reset attacks.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Hollywood Hacker Simulator</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="console"></div>
+<div id="interface">
+  <div id="browser" class="panel">
+    <h2>Secure Files</h2>
+    <ul>
+      <li class="file">blueprints
+        <ul>
+          <li>icbm-missile-design.pdf</li>
+          <li>space-laser-schematics.dxf</li>
+        </ul>
+      </li>
+      <li class="file">nuclear_launch_codes.txt</li>
+      <li class="file">bunker_and_silo_locations.geojson</li>
+      <li class="file">agent_identities.csv</li>
+      <li class="file">secret_projects
+        <ul>
+          <li>project-bluebook.txt</li>
+          <li>psyops-mind-control.docx</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div id="map" class="panel">
+    <svg id="world" viewBox="0 0 1000 500">
+      <path d="M80 120 L150 60 L220 80 L250 140 L210 170 L150 150 Z" class="land"/>
+      <path d="M260 120 L320 80 L400 90 L460 120 L480 170 L430 190 L360 160 Z" class="land"/>
+      <path d="M480 120 L560 110 L630 90 L700 120 L680 180 L600 200 L530 170 Z" class="land"/>
+      <path d="M630 200 L670 240 L650 280 L600 290 L570 260 Z" class="land"/>
+      <path d="M350 220 L380 260 L360 300 L300 290 L280 250 Z" class="land"/>
+      <g id="traces"></g>
+    </svg>
+  </div>
+  <div id="firewall" class="panel">
+    <h2>Firewall Status</h2>
+    <div class="layer"><span>Perimeter</span><div class="bar"><div id="bar1"></div></div></div>
+    <div class="layer"><span>Internal</span><div class="bar"><div id="bar2"></div></div></div>
+    <div class="layer"><span>Core</span><div class="bar"><div id="bar3"></div></div></div>
+    <button id="counter">Deploy Countermeasure</button>
+  </div>
+</div>
+<div id="popups"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,78 @@
+const consoleEl = document.getElementById('console');
+function log(message){
+  const line = document.createElement('div');
+  line.textContent = message;
+  consoleEl.appendChild(line);
+  consoleEl.scrollTop = consoleEl.scrollHeight;
+}
+function randomIP(){
+  return Array(4).fill(0).map(()=>Math.floor(Math.random()*256)).join('.');
+}
+function randomLog(){
+  const ips = randomIP()+" -> "+randomIP();
+  const msgs = [
+    `Connection from ${ips}`,
+    `Packet sniff ${ips}`,
+    `AUTH FAIL ${ips}`,
+    `Decrypting cipher from ${ips}`,
+    `Launching trace route to ${randomIP()}`
+  ];
+  return msgs[Math.floor(Math.random()*msgs.length)];
+}
+setInterval(()=>log(randomLog()),500);
+
+let breachLevel = 0;
+function stepAttack(){
+  breachLevel += 5;
+  updateBars();
+  if(breachLevel === 30) popup('Perimeter breached');
+  if(breachLevel === 60) popup('Internal firewall compromised');
+  if(breachLevel >= 100){
+    popup('Core systems infiltrated: data exfiltration in progress');
+    breachLevel = 0;
+  }
+}
+function updateBars(){
+  document.getElementById('bar1').style.width = Math.min(breachLevel,30)+"%";
+  document.getElementById('bar2').style.width = Math.max(Math.min(breachLevel-30,30),0)+"%";
+  document.getElementById('bar3').style.width = Math.max(Math.min(breachLevel-60,40),0)+"%";
+}
+setInterval(stepAttack,1000);
+
+const traces = document.getElementById('traces');
+function drawTrace(){
+  const x1 = Math.random()*1000;
+  const y1 = Math.random()*250+50;
+  const x2 = 500;
+  const y2 = 250;
+  const line = document.createElementNS('http://www.w3.org/2000/svg','line');
+  line.setAttribute('x1',x1);
+  line.setAttribute('y1',y1);
+  line.setAttribute('x2',x2);
+  line.setAttribute('y2',y2);
+  line.setAttribute('class','trace');
+  traces.appendChild(line);
+  setTimeout(()=>line.remove(),2000);
+}
+setInterval(drawTrace,800);
+
+document.getElementById('counter').addEventListener('click',()=>{
+  breachLevel = 0;
+  updateBars();
+  popup('Countermeasure deployed, attacker traced');
+});
+
+function popup(text){
+  const pop = document.createElement('div');
+  pop.className = 'popup';
+  pop.textContent = text;
+  document.getElementById('popups').appendChild(pop);
+  setTimeout(()=>pop.remove(),3000);
+}
+
+document.querySelectorAll('#browser li').forEach(li=>{
+  li.addEventListener('click',e=>{
+    e.stopPropagation();
+    popup('Accessing '+li.textContent.trim());
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,81 @@
+body{
+  background:#000;
+  color:#0f0;
+  font-family:monospace;
+  margin:0;
+}
+#console{
+  position:fixed;
+  bottom:0;
+  left:0;
+  height:150px;
+  overflow:auto;
+  width:100%;
+  background:#010;
+  opacity:0.8;
+  font-size:12px;
+}
+#interface{
+  display:flex;
+  height:calc(100vh - 150px);
+}
+.panel{
+  flex:1;
+  padding:10px;
+  overflow:auto;
+}
+#browser ul{
+  list-style:none;
+  padding-left:10px;
+}
+#browser li{
+  cursor:pointer;
+}
+#map svg{
+  width:100%;
+  height:100%;
+}
+.land{
+  fill:#222;
+  stroke:#0a0;
+  stroke-width:1;
+}
+.trace{
+  stroke:#0f0;
+  stroke-width:2;
+  opacity:0.7;
+  stroke-dasharray:5;
+  animation:fade 2s linear forwards;
+}
+@keyframes fade{
+  from{opacity:1;}
+  to{opacity:0;}
+}
+.layer{
+  margin:10px 0;
+}
+.bar{
+  background:#333;
+  height:10px;
+  width:100%;
+}
+.bar div{
+  background:#f00;
+  height:100%;
+  width:0%;
+  transition:width 1s linear;
+}
+.popup{
+  position:fixed;
+  top:20px;
+  right:20px;
+  background:red;
+  color:white;
+  padding:10px;
+  margin-top:5px;
+  animation:fadeout 3s forwards;
+}
+@keyframes fadeout{
+  from{opacity:1;}
+  to{opacity:0;}
+}


### PR DESCRIPTION
## Summary
- Add interactive Hollywood-style hacking simulator with scrolling logs, world map traces, and firewall breach indicators
- Include fictional file browser and countermeasure button for interactivity
- Document usage in README

## Testing
- `node --check script.js` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*
- `python -m py_compile script.js` *(fails: invalid syntax since file is JavaScript)*


------
https://chatgpt.com/codex/tasks/task_e_68b96fbad0888328b053d045234a3878