### PR TITLE
Replace placeholder map with real world outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,11 +30,13 @@
   </div>
   <div id="map" class="panel">
     <svg id="world" viewBox="0 0 1000 500">
-      <path d="M80 120 L150 60 L220 80 L250 140 L210 170 L150 150 Z" class="land"/>
-      <path d="M260 120 L320 80 L400 90 L460 120 L480 170 L430 190 L360 160 Z" class="land"/>
-      <path d="M480 120 L560 110 L630 90 L700 120 L680 180 L600 200 L530 170 Z" class="land"/>
-      <path d="M630 200 L670 240 L650 280 L600 290 L570 260 Z" class="land"/>
-      <path d="M350 220 L380 260 L360 300 L300 290 L280 250 Z" class="land"/>
+      <path d="M70 110 L120 60 L200 40 L260 80 L300 120 L280 160 L240 170 L220 200 L200 220 L160 210 L140 180 L100 150 Z" class="land"/>
+      <path d="M250 230 L280 260 L300 300 L290 340 L280 380 L260 430 L240 380 L230 320 L240 280 Z" class="land"/>
+      <path d="M340 80 L400 60 L460 60 L520 80 L560 60 L620 80 L680 100 L740 120 L780 160 L820 200 L840 240 L820 260 L780 240 L740 220 L700 220 L660 200 L620 200 L580 180 L540 180 L500 160 L460 140 L420 140 L380 120 Z" class="land"/>
+      <path d="M480 200 L520 220 L560 260 L560 320 L540 360 L500 420 L460 360 L440 300 L440 240 Z" class="land"/>
+      <path d="M760 320 L780 300 L820 300 L860 320 L880 360 L860 400 L820 400 L780 380 Z" class="land"/>
+      <path d="M200 40 L240 20 L280 40 L260 80 L220 80 Z" class="land"/>
+      <path d="M0 460 L1000 460 L1000 500 L0 500 Z" class="land"/>
       <g id="traces"></g>
     </svg>
   </div>


### PR DESCRIPTION
## Summary
- Swap stylized shapes for simplified real-world continent outlines in the map SVG
- Include Antarctica and Greenland to improve recognizability

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab32b118c83288324c240788b7d57